### PR TITLE
Django 3.0 support

### DIFF
--- a/classytags/__init__.py
+++ b/classytags/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.9.0'
+__version__ = '1.0.0'

--- a/classytags/__init__.py
+++ b/classytags/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.0'
+__version__ = '0.9.0'

--- a/classytags/core.py
+++ b/classytags/core.py
@@ -2,7 +2,7 @@
 from operator import attrgetter
 
 from django.template import Node
-from django.utils import six
+import six
 
 from classytags.blocks import BlockDefinition
 from classytags.parser import Parser

--- a/classytags/utils.py
+++ b/classytags/utils.py
@@ -4,7 +4,7 @@ from copy import copy
 
 from django.template import Context, RequestContext
 from django.template.context import BaseContext
-from django.utils import six
+import six
 
 
 class NULL:

--- a/classytags/values.py
+++ b/classytags/values.py
@@ -3,7 +3,7 @@ import warnings
 
 from django import template
 from django.conf import settings
-from django.utils import six
+import six
 
 from classytags.exceptions import TemplateSyntaxWarning
 


### PR DESCRIPTION
Added Django 3.0 support by removing ``from django.utils import six`` and adding ``six``
Updated package version.