### PR TITLE
Remove all-encompassing python support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
-    'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
This line identfying Python without providing a version results it being counted for all Python versions. Having recently dropped Python 2 support, this current Python 3-only version is being distributed to Python 2 projects by PyPi.